### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This fork has been superceded by <https://github.com/staxrip/staxrip>**
+
 ![alt text](https://github.com/Revan654/staxrip/blob/master/docs/screenshots/_Main.png "Main Window")
 
 # Pipeline


### PR DESCRIPTION
Given https://github.com/Revan654/staxrip/issues/99#issuecomment-500587800, it makes sense to inform users that this fork is no longer maintained.